### PR TITLE
Various improvements - see description

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -55,7 +55,7 @@ nitsanavni:
   member: no
 claresudbery:
   title: Clare Sudbery
-  url: https://insimpleterms.blog/
+  url: https://tinyurl.com/SSE-Ltd
   affiliation: Sudbery Software Engineering Ltd
   member: no
 xaviametller:

--- a/_learning_hours/refactoring/lift_up_conditional.md
+++ b/_learning_hours/refactoring/lift_up_conditional.md
@@ -12,25 +12,24 @@ via: xaviametller
 
 Using the "Lift-Up Conditional" refactoring to detangle complex if statements. 
 
-This is a powerful, satisfying and almost magical refactoring technique. It’s really useful for detangling complex knots of if statements. Llewelyn Falco came up with the technique, and Emily Bache named it. There’s a good video by Emily demonstrating the technique [here](https://www.youtube.com/watch?v=OJmg9aMxPDI).
+This is a powerful, satisfying and almost magical refactoring technique. It’s really useful for detangling complex knots of if statements. Llewelyn Falco showed the technique to Emily Bache, and she named it. There’s a good video by Emily demonstrating the technique [here](https://www.youtube.com/watch?v=OJmg9aMxPDI).
 
-The basic principle is to find conditions that are repeated throughout the code and then “lift them up” so that each condition has its own dedicated branch of the code. The result is that we can replace the original complex if statement with a switch statement. Once we’ve done that, we can replace the switch statement with polymorphism (see [Replace Conditional With Polymorphism]({% link _learning_hours/refactoring/conditional_to_polymorphism.md %})).
+The basic principle is to find conditions that are repeated throughout the code and then “lift them up” so that each condition has its own dedicated branch of the code. The result is much simpler and easier to read. 
 
 In this learning hour we demonstrate the technique, and then let the participants try it out for themselves on the [Gilded Rose Refactoring Kata]({% link _kata_descriptions/gilded_rose.md %}). You can do this in one hour, but as the technique takes a bit of time to really understand, it’s a good idea to do this [intro learning hour]({% link _learning_hours/refactoring/lift_up_conditional_intro.md %}) first.
 
-This [slide deck](https://docs.google.com/presentation/d/11HjxVD99vyKyt8HT_5UHIBnAnr4Pck5g/edit?usp=sharing&ouid=117794872566978197093&rtpof=true&sd=true) (also available as a [pdf](https://drive.google.com/file/d/11cEwkIv2NRWLkSCQfqltXIkNUTzCQFyW/view?usp=sharing)) contains all the resources on this page plus more - many of which may be useful in preparing for this learning hour.
-
+The [slide deck](https://docs.google.com/presentation/d/11HjxVD99vyKyt8HT_5UHIBnAnr4Pck5g/edit?usp=sharing&ouid=117794872566978197093&rtpof=true&sd=true) (also available as a [pdf](https://drive.google.com/file/d/11cEwkIv2NRWLkSCQfqltXIkNUTzCQFyW/view?usp=sharing)) contains all the resources on this page plus more - many of which may be useful in preparing for this learning hour.
 
 ### Learning Goals
 
-- Use Keyboard shortcuts to do Lift-up conditional on Gilded Rose
-- Recognize when Lift-up conditional would be an appropriate technique to try  
+- Use Keyboard shortcuts to do Lift-Up Conditional on Gilded Rose
+- Recognize when Lift-Up Conditional would be an appropriate technique to try  
 
 ## Session Outline
 
-* 5 min connect: favourite keyboard shortcuts
-* 15 min concept: Lift-up conditional
-* 30 min concrete: Do Lift-up conditional on Gilded Rose
+* 10 min connect: Favourite keyboard shortcuts
+* 15 min concept: Lift-Up Conditional
+* 30 min concrete: Do Lift-Up Conditional on Gilded Rose
 * 5 min conclusions: What's been learnt
 
 ### Connect: Favourite Keyboard Shortcuts
@@ -39,29 +38,28 @@ As a whole group, ask participants to answer the question “What are your favou
 
 You can ask them to write their answers on stickies using a tool like Miro, Mural or Jamboard, or in bullet points in a shared doc, or on actual stickies in person.
 
-This is a good exercise to get them thinking about keyboard shortcuts, which witruell be useful in this exercise and are demonstrated in the videos linked to below. Hopefully some of them will learn new shortcuts as a result of this exercise.
+This is a good exercise to get them thinking about keyboard shortcuts, which will be useful in this exercise and are demonstrated in the videos linked to below. Hopefully some of them will learn new shortcuts as a result of this exercise.
 
-### Concept: Lift-up Conditional Demo
+### Concept: Lift-Up Conditional Demo
+
 I find it helpful to use schematics to visualise what’s happening, as if you haven’t seen the technique before it can be confusing at first. I also show the Gilded Rose code before and after, to show what we’re aiming for and get them primed for what I’m about to demonstrate.
 
 ![Lift Up Conditional Simple Schematic](/assets/images/lift_up_conditional_simple_schematic.png){: width="600"}
 
-This [slide deck](https://docs.google.com/presentation/d/11HjxVD99vyKyt8HT_5UHIBnAnr4Pck5g/edit?usp=sharing&ouid=117794872566978197093&rtpof=true&sd=true) (also available as a [pdf](https://drive.google.com/file/d/11cEwkIv2NRWLkSCQfqltXIkNUTzCQFyW/view?usp=sharing)) contains two versions of the schematic above, as well as a more detailed example using the same principle. I recommend only using the more detailed version if you are planning to devote two learning hours to this activity. Even then, you may prefer the shorter simpler version.
+This [slide deck](https://docs.google.com/presentation/d/11HjxVD99vyKyt8HT_5UHIBnAnr4Pck5g/edit?usp=sharing&ouid=117794872566978197093&rtpof=true&sd=true) (also available as a [pdf](https://drive.google.com/file/d/11cEwkIv2NRWLkSCQfqltXIkNUTzCQFyW/view?usp=sharing)) contains two versions of the schematic above, as well as a more detailed example using the same principle. I recommend only using the more detailed version if you're planning to devote two learning hours to this activity. Even then, you may prefer the shorter simpler version.
 
-I follow the schematics with this video of a [C# demo of the technique](https://vimeo.com/801311948/41a83a3c4e), played at double speed, with me talking over the top. [This branch of the Gilded Rose kata](https://github.com/claresudbery/GildedRose-Refactoring-Kata/tree/csharp-liftup-demo) contains a commit for every step I made in the video. The tests were passing at each commit. There is also this [video of Emily Bache demonstrating the technique in Java](https://www.youtube.com/watch?v=OJmg9aMxPDI), but it’s quite long so you might want to make your own or select only some short snippets to show.
+I follow the schematics with this video of a [C# demo of the technique](https://vimeo.com/801311948/41a83a3c4e), played at double speed, with me talking over the top. [This branch of the Gilded Rose kata](https://github.com/claresudbery/GildedRose-Refactoring-Kata/tree/csharp-liftup-demo) contains a commit for every step I made in the video. The tests were passing at each commit. If you like, you can [share this link](https://github.com/claresudbery/GildedRose-Refactoring-Kata/blob/csharp-liftup-demo/csharp/GildedRose.cs) to show them what they're aiming for when they're done. There is also this [video of Emily Bache demonstrating the technique in Java](https://www.youtube.com/watch?v=OJmg9aMxPDI), but it’s quite long so you might want to make your own or select only some short snippets to show.
 
-### Concrete: Do Lift-up Conditional
+### Concrete: Do Lift-Up Conditional
 
-In pairs, ask them to attempt the technique themselves on the Gilded Rose code base. Encourage them to move in small steps and make sure the tests pass after each tiny change. For C#, I give them [this C# starting point](https://github.com/claresudbery/GildedRose-Refactoring-Kata/tree/csharp-liftup-start. I did the following, which got them moving as quickly as possible:
+In pairs, ask them to attempt the technique themselves on the Gilded Rose code base. Encourage them to move in small steps and make sure the tests pass after each tiny change. For C#, I give them [this C# starting point](https://github.com/claresudbery/GildedRose-Refactoring-Kata/tree/csharp-liftup-start). The following will get them moving as quickly as possible:
 
 * All other languages have been removed from this branch, to avoid distraction and make it clear where to start
 * The approval tests are set up for maximum coverage and will pass as soon as they open the code
-* Participants downloaded the code and made sure they could build it and make the tests pass before we started the workshop (I have [notes on how to handle any Visual-Studio-related gotchas](https://clare-wiki.herokuapp.com/pages/think/code-princ/Gilded-Rose#gilded-rose-working-in-visual-studio))
+* It's best for participants to download the code and make sure they can build it and make the tests pass before you start the workshop (I have [notes on how to handle any Visual-Studio-related gotchas](https://clare-wiki.herokuapp.com/pages/think/code-princ/Gilded-Rose#gilded-rose-working-in-visual-studio))
 
 I also added the above schematic and these [instructions on using the approval tests](https://clare-wiki.herokuapp.com/pages/think/code-princ/Gilded-Rose#gilded-rose-getting-started-with-approval-tests-in-c) to a central location (a Mural board and a Google doc) which all participants could access.
 
-### Conclusions: Reflect on what's been learnt
+### Conclusions: When should you use this?
 
-Ask the two simple questions below, and give partipants some simple way of choosing from the multiple choice answers (I created several yellow stars that participants could pick up and move into the relevant space - see image below). This gives you an idea of how well the learning hour has gone, and also gives participants a way of reinforcing in their own heads the value of the workshop.
-
-![img.png](/assets/images/how_confident_lift_up_conditional.png){: width="600"}
+Ask them to discuss, in pairs, when they would use this technique. A good outcome to aim for is at least one sticky note from each pair on a central board (or a bullet point added to a shared doc).

--- a/_learning_hours/refactoring/lift_up_conditional_intro.md
+++ b/_learning_hours/refactoring/lift_up_conditional_intro.md
@@ -14,14 +14,14 @@ Introduction to the "Lift-Up Conditional" refactoring to detangle complex if sta
 
 ### Learning Goals
 
-- Use Keyboard shortcuts to do Lift-up conditional on a simple example
+- Use Keyboard shortcuts to do Lift-Up Conditional on a simple example
 
 ## Session Outline
 
-* 10 min connect: if-parsing exercise
-* 10 min concept: Lift-up conditional
-* 20 min concrete: Do Lift-up conditional on practice exercise
-* 10 min concept: Lift-up conditional on Gilded Rose
+* 10 min connect: If-parsing exercise
+* 10 min concept: Lift-Up Conditional
+* 20 min concrete: Do Lift-Up Conditional on practice exercise
+* 10 min concept: Lift-Up Conditional on Gilded Rose
 * 5 min conclusions: Note shortcuts
 
 ### Connect: if-parsing exercise
@@ -30,29 +30,41 @@ In pairs: Which if statements are equivalent? Join them up. Because they are abo
 
 Below are the if statements I use, each statement paired with the correct answer. You can use a visual tool like Miro or Mural to join text boxes with arrows, or print them out on paper, or find another technique that fits your situation.
 
+If you want to add your own equivalent if statements, you might like to use [this C# test code](https://github.com/claresudbery/GildedRose-Refactoring-Kata/blob/82e3c4f430153707eea0de4255fc09859ee6b5fe/csharp/BooleanParsingTests.cs#L55) I created to check each if statement is definitely equivalent (the link takes you to a method that demonstrates how the tests work).
+
 <pre>
 // First pair
 if(colour1 == colour1 && colour2 == colour2)
 if(true)
+
 // Second pair
 if(colour1 == "green" && colour1 == "blue")
 if(false)
+
 // Third pair
 if(colour1 != "green" && colour2 != "blue")
 if(!(colour1 == "green" || colour2 == "blue"))
+
 // Fourth pair
 if(!(colour1 != "green" && colour2 != "blue"))
 if(colour1 == "green" || colour2 == "blue")
+
 // Fifth pair
 if(!(colour1 == "green" && colour2 == "blue"))
 if(colour1 != "green" || colour2 != "blue")
 </pre>
 
-Below is a sample of what the solution looks like in Mural. I suggest that, if using a tool like Mural or Miro, you create a separate frame for each pair to use for the exercise.
+Below is a sample of what the solution looks like in Mural. I suggest that, if using a tool like Mural or Miro, you create a separate frame for each pair to use for the exercise. You can create a separate frame containing the solution, which stays hidden until they've done the exercise themselves.
 
 ![if-parsing exercise solution](/assets/images/if-parsing-solution.png){: width="600"}
 
-## Concept: Lift-up Conditional
+## Concept part 1: Lift-Up Conditional
+
+I find it helpful to use schematics to visualise what’s happening, as if you haven’t seen the technique before it can be confusing at first.
+
+![Lift Up Conditional Simple Schematic](/assets/images/lift_up_conditional_simple_schematic.png){: width="600"}
+
+## Concept part 2: Lift-Up Conditional Demo
 
 Demonstrate the technique on a simple conditional first. For example:
 
@@ -90,7 +102,7 @@ Show the keyboard shortcuts you are using, and write them up on a list where peo
 
 Ask people to do the same exercise you just demoed, and use the keyboard shortcuts in their IDE.
 
-### Concept: Lift-up conditional on Gilded Rose
+### Concept: Lift-Up Conditional on Gilded Rose
 
 Show the complex conditional in Gilded Rose and how you can use this technique to simplify it. If you are doing the [follow-up learning hour using this technique]({% link _learning_hours/refactoring/lift_up_conditional.md %}), it is the same demo. You might not show the whole demo today, but you can make a start. It helps to see it twice :-)
 


### PR DESCRIPTION
- Either capitalise all of "Lift-Up Conditional" or none of it - I've gone for all of it (if you don't like this we could try italicising the phrase instead?)
- Capitals after colons
- Fix the typo spotted by Xavi
- Insert blank lines in if-parsing exercise for readability
- Add suggestion to create hidden if-parsing solution frame
- Intro: Add schematic to the first concept part
- For accuracy, edit to say Llewellyn showed the technique to Emily
- Remove mention of switch statements or polymorphism, to handle both (albeit different) issues raised by Emily and Xavi.
- Change Connect timing back to 10 mins - I considered leaving it at 5 and making the Concrete part longer to compensate, but my experience is that there's often a delay getting everyone present and ready to go anyway, so a longer Connect allowance can cater for that.
- "you are" => "you're" - less formal
- fix broken link (had missing closing bracket on the url)
- Stop mixing tenses between present and past (improving on my original text)
- Part 2: New Conclusion activity as suggested by Emily.
- Added link to finished version of code, to demonstrate what people are aiming for.
- Added link to the code I wrote to test the if statements were definitely equivalent in the if-parsing exercise.
- Changed my URL in contributors.yml