### PR TITLE
Print version of the site

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,34 @@
-<hr>
 <footer>
-	License: <a href="/LICENSE.html">CC-BY-SA-4.0</a>. Attribution: <a href="/">sammancoaching.org</a>
+	<div class="web-licence">
+		<hr>
+		License: <a href="/LICENSE.html">CC-BY-SA-4.0</a>.
+		{% assign person = site.data.contributors[page.author] %}
+		{% assign via = site.data.contributors[page.via] %}
+		Attribution:
+		{% if person %}
+		<a href="/society/contributors/{{ page.author }}.html">{{ person.title }}</a>
+		{% endif %}
+
+		{% if via %}
+		& <a href="/society/contributors/{{ page.via }}.html">{{ via.title }}</a> -
+		{% elsif page.affiliation %}
+		- {{ page.affiliation }} -
+		{% endif %}
+		<a href="/">sammancoaching.org</a>
+	</div>
+	<div class="print-licence">
+		Attribution:
+		{% if person %}
+		{{person.title}}
+		{% endif %}
+		{% if via %}
+		 & {{via.title}},
+		{% elsif page.affiliation %}
+		, {{page.affiliation}},
+		{% endif %}
+		sammancoaching.org
+		<br>
+		License: This material is licensed with CC-BY-SA-4.0 https://creativecommons.org/licenses/by-sa/4.0/
+		<br>
+	</div>
 </footer>

--- a/_layouts/learning_hour.html
+++ b/_layouts/learning_hour.html
@@ -2,16 +2,4 @@
 layout: default
 ---
 {{ content }}
-<hr>
-<footer>
-    {% assign person = site.data.contributors[page.author] %}
-    {% assign via = site.data.contributors[page.via] %}
-    License: <a href="/LICENSE.html">CC-BY-SA-4.0</a>.
-    Attribution: <a href="/society/contributors/{{ page.author }}.html">{{ person.title }}</a>
-    {% if via %}
-        & <a href="/society/contributors/{{ page.via }}.html">{{ via.title }}</a>
-    {% elsif page.affiliation %}
-        - {{ page.affiliation }}
-    {% endif %}
-    - <a href="/">sammancoaching.org</a>
-</footer>
+{% include footer.html %}

--- a/_sass/_print.scss
+++ b/_sass/_print.scss
@@ -1,0 +1,27 @@
+@import "colors";
+
+.print-licence{
+  display:none;
+}
+@media print {
+  div {
+    break-inside: avoid;
+  }
+  .banner {
+    display: none;
+  }
+  .site-nav {
+    display: none;
+  }
+
+  .print-licence{
+    padding: 10px;
+    display: block;
+    border-width: 1px;
+    border-style: solid;
+    border-color: $dark-blue;
+  }
+  .web-licence{
+    display: none;
+  }
+}

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -1,7 +1,7 @@
 @import "navigation";
 @import "colors";
 @import "variables";
-
+@import "print";
 .current {
 	color: $light-blue;
 }
@@ -23,6 +23,7 @@ img[src*="#book_cover"] {
 	position: relative;
 	left: 250px;
 }
+
 
 @media screen and (max-width: $on-medium) {
   .banner{


### PR DESCRIPTION
Creating one footer to be used in most places, so that copyright information can be printed with proper links.

Removing the banner in print

Telling the rendering not to break pages in a div if it can.

To verify:

Go to a page and look at the print preview.
The image at top and the icon for navigation should be gone
The copyright information at the bottom should have all information in clear text.>

I also did a refactor in the footers in general, I have tried to make sure I did not change anything there.