### PR TITLE
Trying Matomo tracking on the Samman website

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,4 +11,28 @@
     <meta name="theme-color" content="#ffffff">
     {% feed_meta %}
     {% seo %}
+
+    {% if jekyll.environment == "production" %}
+    <!-- Matomo -->
+    <script>
+        var _paq = window._paq = window._paq || [];
+        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+        _paq.push(["setDoNotTrack", true]);
+        // accurately measure the time spent in the visit
+        _paq.push(['enableHeartBeatTimer']);
+        _paq.push(["disableCookies"]);
+        _paq.push(['trackPageView']);
+        _paq.push(['enableLinkTracking']);
+        /* Samman site tracking is currently brought to you by Chocolate Driven Development, hence the url */
+        (function() {
+            var u="https://chocolatedrivendevelopment.matomo.cloud/";
+            _paq.push(['setTrackerUrl', u+'matomo.php']);
+            _paq.push(['setSiteId', '2']);
+            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+            g.async=true; g.src='https://cdn.matomo.cloud/chocolatedrivendevelopment.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+        })();
+    </script>
+    <!-- End Matomo Code -->
+    {% endif %}
+
 </head>


### PR DESCRIPTION
Added tracking code to the head of the site. Only enabled in production. 
No cookies, but heartbeat. IP masked to six digits. 