### PR TITLE
Fix link to Word Wrap kata in LH "Fluency with TDD"

### DIFF
--- a/_learning_hours/small_steps/tdd_fluency.md
+++ b/_learning_hours/small_steps/tdd_fluency.md
@@ -44,7 +44,7 @@ Tell a story about learning a skill like dancing or cooking or skiing or playing
 Today we're training TDD fluency. You get good at doing something by practicing it and reflecting.
 
 ### Do: Word Wrap
-Practice breaking the problem into small pieces by making a test list. Practice writing the design in the test first before you create the function. Practice making the tests pass one at a time. Practice updating your test list. Practice refactoring to remove duplication. Suggested kata - [Word Wrap](kata_descriptions/word_wrap.html).
+Practice breaking the problem into small pieces by making a test list. Practice writing the design in the test first before you create the function. Practice making the tests pass one at a time. Practice updating your test list. Practice refactoring to remove duplication. Suggested kata - [Word Wrap]({% link _kata_descriptions/word_wrap.md %}).
 
 For each aspect of TDD that you're practicing, pay attention to how fluent it feels and how easily you can do it.
 


### PR DESCRIPTION
Fixes the link to the Word Wrap kata description markdown file in the learning hour "Fluency with TDD".