### PR TITLE
. e Add Claude Code authoring skills

### DIFF
--- a/.claude/skills/commit-notation/SKILL.md
+++ b/.claude/skills/commit-notation/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: commit-notation
+description: Write commit messages using Arlo's Commit Notation (ACN) — a one-or-two-character prefix encoding the change's risk and type. Use when committing in this repo, or when asked to classify or rewrite a commit message in ACN. Triggers on "commit notation", "Arlo's notation", "ACN", "what prefix should this commit have".
+---
+
+# Arlo's Commit Notation (ACN)
+
+Every commit subject starts with a **risk marker** and a **type letter**, then a space, then a
+present-tense description:
+
+```
+[risk][type] description
+```
+
+Examples: `. e Add commit-notation skill`, `! F use ical to get training dates`, `. r Extract method`.
+
+Source: <https://github.com/RefactoringCombos/ArlosCommitNotation>
+
+## Type letters
+
+| Letter | Type | Meaning |
+|--------|------|---------|
+| `F` / `f` | Feature | Change or extend one aspect of program behavior without altering others. |
+| `B` / `b` | Bugfix | Repair one existing, undesirable behavior without altering any others. |
+| `R` / `r` | Refactoring | Change implementation **without** changing program behavior. |
+| `D` / `d` | Documentation | Communicates to team members; no impact on program behavior. |
+| `e` | Environment *(repo extension)* | Build, CI, config, dev-tooling and agent tooling (`.claude/skills`, `.windsurf`, `.gitignore`, workflows). No product behavior change. |
+
+**Case:** uppercase = the change is **user-visible / behavior-changing** (belongs in a changelog);
+lowercase = **internal only**, no behavior change. So a feature users will notice is `F`; a
+developer-only feature is `f`. Refactoring and docs are normally lowercase (`r`, `d`).
+
+## Risk markers
+
+| Marker | Level | Meaning |
+|--------|-------|---------|
+| `.` | Safe | Addresses all known **and unknown** risks. Provable refactoring, pure additions, test-only or tooling changes. |
+| `^` | Validated | Addresses all **known** risks; intended change is verified. **This repo writes this as `-`.** |
+| `!` | Risky | Some known risks remain unverified; only the intended change is checked. |
+| `@` | Broken | No attestation — may not even compile. Avoid except on private WIP. |
+
+> **House style:** this repo uses **`-` instead of `^`** for *validated*, and uses **`e`** for
+> environment/tooling. Match the surrounding history: `git log --oneline` to see recent prefixes.
+
+## Rules of thumb
+
+- **One behavior change per `F`/`B`.** More than one behavior change drops you to `@`.
+- **`^`/`-` for `F`/`B` only if ≤ 8 lines changed** (tests included) and the change is validated.
+- **`. r`** requires a *provable* refactoring (tool-assisted) or a refactoring confined to test code.
+- **`. F`/`. f`** requires the feature to be developer-only, or to meet all validated-feature criteria.
+- Pure additions of files that cannot break existing behavior (new tooling, new docs) are `.`.
+
+## How to classify a commit
+
+1. **Type:** Does it change product behavior users care about? → `F`/`B`. Behavior-preserving code
+   change? → `r`. Team-facing text only? → `d`. Build/CI/config/agent tooling? → `e`.
+2. **Case:** user-visible → uppercase; internal-only → lowercase.
+3. **Risk:** Provably safe / pure addition / tool-assisted? → `.`. Validated but not proven (and
+   small)? → `-` (this repo) / `^`. Intended change works but risks unverified? → `!`.
+4. Prepend `[risk][type] ` to a concise, present-tense subject. Check `git log` for local style.

--- a/.claude/skills/create-learning-hour/SKILL.md
+++ b/.claude/skills/create-learning-hour/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: create-learning-hour
-description: Author a Learning Hour (Emily Bache's time-boxed Connect/Concept/Concrete/Conclusions workshop format) for the website's _learning_hours/ collection. Use when creating a new learning hour, or restructuring workshop notes into the site format. Triggers on "create a learning hour", "add a learning hour", "write a workshop session".
+description: Author a Learning Hour (a time-boxed Connect/Concept/Concrete/Conclusions workshop using Sharon Bowman's 4C format) for the website's _learning_hours/ collection. Use when creating a new learning hour, or restructuring workshop notes into the site format. Triggers on "create a learning hour", "add a learning hour", "write a workshop session".
 ---
 
 # Create a Learning Hour
 
-A Learning Hour is a time-boxed, interactive workshop following Emily Bache's 4C format
-(Connect, Concept, Concrete, Conclusions). Gather the content, structure the document,
+A Learning Hour is a time-boxed, interactive workshop following the 4C format
+(Connect, Concept, Concrete, Conclusions) from Sharon Bowman's *Training from the Back of the Room*. Gather the content, structure the document,
 and place it under `_learning_hours/<theme>/`.
 
 ## Steps

--- a/.claude/skills/create-learning-hour/SKILL.md
+++ b/.claude/skills/create-learning-hour/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: create-learning-hour
+description: Author a Learning Hour (Emily Bache's time-boxed Connect/Concept/Concrete/Conclusions workshop format) for the website's _learning_hours/ collection. Use when creating a new learning hour, or restructuring workshop notes into the site format. Triggers on "create a learning hour", "add a learning hour", "write a workshop session".
+---
+
+# Create a Learning Hour
+
+A Learning Hour is a time-boxed, interactive workshop following Emily Bache's 4C format
+(Connect, Concept, Concrete, Conclusions). Gather the content, structure the document,
+and place it under `_learning_hours/<theme>/`.
+
+## Steps
+
+1. **Collect metadata**
+   - Theme (the folder under `_learning_hours/`, e.g. `ensemble`, `bdd`, `legacy`).
+   - Title (Title-case).
+   - Kata (exercise name or link).
+   - Difficulty (1–5).
+   - Author & affiliation.
+   - Languages and tags (optional).
+
+2. **Interview the writer**
+   - Motivation / intro sentence.
+   - Learning objectives / goals.
+   - Timeboxes for each phase (minutes).
+   - **Connect** — icebreaker or context activity.
+   - **Concept** — theory or demo (sometimes labeled "Demo").
+   - **Concrete** — hands-on tasks (sometimes labeled "Do").
+   - **Conclusions** — wrap-up (sometimes labeled "Reflect").
+   - Any prerequisites (`## Requirements`) or acknowledgements.
+
+3. **Write the sections** using the template below.
+   - Link internal exercises/activities with Jekyll's `link` tag, e.g.
+     `{% link exercises/warm_up_questions/go_syntax.md %}`.
+   - Use standard URLs for external links.
+   - Timings in minutes; bullet lists; imperative voice; consistent heading levels.
+
+4. **Review style & links**
+   - Check synonym consistency (Goals/Objectives, Outline/Session Outline,
+     Concept/Demo, Concrete/Do, Conclusions/Reflect).
+   - Validate every link and the front matter.
+
+5. **Place the file**
+   - Save under `_learning_hours/<theme>/` with a lowercase, underscore filename.
+
+6. **Build & verify**
+   - Run the site locally (`./build_and_run`) and preview in the browser.
+   - Only commit/push when Ivett asks.
+
+## Template
+
+```md
+---
+theme: <theme>
+title: <Title>
+kata: <kata>
+difficulty: <n>
+author: <you>
+affiliation: <org>
+languages: <opt>
+tags: <list>
+---
+
+# <Title>
+<One–two sentence intro>
+
+## Learning Objectives
+- …
+
+## Session Outline
+* <min> connect: …
+* <min> concept: …
+* <min> concrete: …
+* <min> conclusions: …
+
+### Connect: <short label>
+<Instructions & link>
+
+### Concept: <short label>
+<Theory / demo steps>
+
+### Concrete: <short label>
+<Hands-on exercise instructions>
+
+### Conclusions: <short label>
+<Wrap-up questions / links>
+```

--- a/.claude/skills/describe-kata/SKILL.md
+++ b/.claude/skills/describe-kata/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: describe-kata
+description: Write a kata (coding exercise) description for the website's _kata_descriptions/ collection. Use when adding a new kata, or reformatting an existing problem statement to match the site's conventions. Triggers on "write a kata description", "add a kata", "document this exercise".
+---
+
+# Write a Kata Description
+
+Produce a consistent, clear kata description for `_kata_descriptions/<kata_name>.md`. Keep language simple, direct, present-tense, and example-driven.
+
+## Structure
+
+A kata description has these sections, in order:
+
+1. **YAML front matter** — open and close with `---`. Required keys:
+   - `title`: human-friendly name.
+   - `kata_name`: machine identifier in `snake_case` (match the filename).
+2. **Main title** — a Markdown heading with the kata's name.
+3. **Problem description** — state the problem and any scenario. Include sample data, inputs, or outputs in code blocks where helpful.
+4. **Requirements / Rules** — bullet points. For multi-part katas use `## Part 1`, `## Part 2`, etc.
+5. **Examples** — concrete input/output pairs as code or tables.
+6. **Additional Features / Follow-ups** (optional) — stretch goals.
+7. **Acknowledgements** — credit the original author/source with links if applicable.
+
+## Style
+
+- Clarity and brevity; avoid jargon.
+- Neutral, instructive, encouraging tone.
+- Present tense, imperative where giving instructions.
+- Prefer concrete examples over abstract explanation.
+- Save to `_kata_descriptions/<kata_name>.md` with a lowercase filename matching `kata_name`.
+
+## Ask the human if unclear
+
+- Intended title and `snake_case` name?
+- Core problem statement / scenario?
+- Precise requirements or rules?
+- Sample inputs and expected outputs?
+- Edge cases or special rules to highlight?
+- Extensions / follow-up challenges?
+- Who to credit, and any external links?
+
+## Template
+
+```markdown
+---
+title: Example Kata
+kata_name: example_kata
+---
+
+Example Kata
+============
+
+Describe the scenario and problem here.
+
+## Requirements
+
+- List each requirement as a bullet point.
+- Be specific and clear.
+
+## Example
+
+```
+Input: [example input]
+Output: [expected output]
+```
+
+## Additional Features
+
+- Optional: stretch goals or follow-up challenges.
+
+### Acknowledgements
+This kata was inspired by [Author Name](link).
+```

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ credentials.txt
 *.received.*
 /junit-reports
 */settings.local.json
+
+# Agent tooling
+.claude-channel/
+.windsurf/


### PR DESCRIPTION
Adds three contributor skills under `.claude/skills/`: `create-learning-hour`, `describe-kata`, and `commit-notation` (Arlo's Commit Notation), and ignores agent-tooling artifacts.